### PR TITLE
Change "maximize" icon to "window maximize" for proper display

### DIFF
--- a/martor/templates/martor/toolbar.html
+++ b/martor/templates/martor/toolbar.html
@@ -54,7 +54,7 @@
     </div>
 
     <div class="ui icon button no-border markdown-selector markdown-toggle-maximize" title="{% trans 'Full Screen' %}">
-      <i class="maximize icon"></i>
+      <i class="window maximize icon"></i>
     </div>
     <div class="ui icon button no-border markdown-selector markdown-help" title="{% trans 'Markdown Guide (Help)' %}">
       <i class="help circle icon"></i>


### PR DESCRIPTION
The name of the maximize icon changed in semantic ui to window maximize.