### PR TITLE
Add credit for dictionaries for spellchecking

### DIFF
--- a/martor/static/dicts/README.md
+++ b/martor/static/dicts/README.md
@@ -1,0 +1,7 @@
+The text below is copied from @cfinke's [Typo.js project](https://github.com/cfinke/Typo.js/tree/master/typo/dictionaries/en_US):
+
+2006-02-07 release.
+
+This dictionary is based on a subset of the original English wordlist created by Kevin Atkinson for Pspell and Aspell and thus is covered by his original LGPL license. The affix file is a heavily modified version of the original english.aff file which was released as part of Geoff Kuenning's Ispell and as such is covered by his BSD license.
+
+Thanks to both authors for their wonderful work.


### PR DESCRIPTION
I forgot to include a reference to the authors of the dictionary used in the spellchecker merged previously. I want to make sure that credit is received where credit is due! 

Thanks :)