### PR TITLE
Add preview event for extra postprocessing

### DIFF
--- a/martor/static/martor/js/martor.js
+++ b/martor/static/martor/js/martor.js
@@ -163,6 +163,7 @@
                           $('pre').each(function(i, block){
                               hljs.highlightBlock(block);
                           });
+                          $(document).trigger('martor:preview', [currentTab]);
                         }else {currentTab.html('<p>Nothing to preview</p>');}
                     },
                     error: function(response) {


### PR DESCRIPTION
For example, if you need math support inside markdown through MathJax, you can simply do

```javascript
$(document).on('martor:preview', function (e, preview) {
    MathJax.Hub.Queue(['Typeset', MathJax.Hub, preview[0]]);
});
```