### PR TITLE
Wrap editor in a div for proper borders

### DIFF
--- a/martor/templates/martor/editor.html
+++ b/martor/templates/martor/editor.html
@@ -1,18 +1,20 @@
 {% load i18n %}
 <div class="main-martor main-martor-{{ field_name }}" data-field-name="{{ field_name }}">
   <div class="section-martor">
-    <div class="ui top attached tabular pointing secondary menu tab-martor-menu">
-      <a class="item active" data-tab="editor-tab-{{ field_name }}"><i class="edit icon"></i> {% trans "Editor" %}</a>
-      <a class="item" data-tab="preview-tab-{{ field_name }}"><i class="eye icon"></i>{% trans "Preview" %}</a>
-      {% include "martor/toolbar.html" %}
-    </div>
-    <div class="ui bottom attached tab segment active" data-tab="editor-tab-{{ field_name }}">
-      <div class="ui active dimmer upload-progress" style="display:none">
-        <div class="ui text loader">{% trans "Uploading... please wait..." %}</div>
+    <div class="section-martor-editor">
+      <div class="ui top attached tabular pointing secondary menu tab-martor-menu">
+        <a class="item active" data-tab="editor-tab-{{ field_name }}"><i class="edit icon"></i> {% trans "Editor" %}</a>
+        <a class="item" data-tab="preview-tab-{{ field_name }}"><i class="eye icon"></i>{% trans "Preview" %}</a>
+        {% include "martor/toolbar.html" %}
       </div>
-      <div id="martor-{{ field_name }}" class="martor-field martor-field-{{ field_name }}"></div>
-      {{ martor }}
-      <i class="angle double down grey icon expand-editor"></i>
+      <div class="ui bottom attached tab segment active" data-tab="editor-tab-{{ field_name }}">
+        <div class="ui active dimmer upload-progress" style="display:none">
+          <div class="ui text loader">{% trans "Uploading... please wait..." %}</div>
+        </div>
+        <div id="martor-{{ field_name }}" class="martor-field martor-field-{{ field_name }}"></div>
+        {{ martor }}
+        <i class="angle double down grey icon expand-editor"></i>
+      </div>
     </div>
     <div class="ui bottom attached tab segment martor-preview" data-tab="preview-tab-{{ field_name }}">
       <p>{% trans "Nothing to preview" %}</p>


### PR DESCRIPTION
In live mode, before:

![image](https://user-images.githubusercontent.com/1403503/68096569-8d833a00-fe7f-11e9-8104-cb88304e43bf.png)

After:

![image](https://user-images.githubusercontent.com/1403503/68096559-7a706a00-fe7f-11e9-85a9-8067e8f982dd.png)
