### PR TITLE
Request Markdown rendering on page load

### DIFF
--- a/martor/static/martor/js/martor.js
+++ b/martor/static/martor/js/martor.js
@@ -128,12 +128,6 @@
             $(obj).find('.modal-help-guide').attr({'data-field-name': field_name});
             $(obj).find('.modal-emoji').attr({'data-field-name': field_name});
 
-            // Set if editor has changed.
-            editor.on('change', function(evt){
-                var value = editor.getValue();
-                textareaId.val(value);
-            });
-
             // resize the editor using `resizable.min.js`
             $('#'+editorId).resizable({
                 direction: 'bottom',
@@ -146,7 +140,7 @@
             var currentTab = $('.tab.segment[data-tab=preview-tab-'+field_name+']');
             var previewTabButton = $('.item[data-tab=preview-tab-'+field_name+']');
             var refreshPreview = function() {
-                var value = editor.getValue();
+                var value = textareaId.val();
                 var form = new FormData();
                 form.append('content', value);
                 form.append('csrfmiddlewaretoken', getCookie('csrftoken'));
@@ -171,9 +165,19 @@
                 });
             };
 
-            if (editorConfig.living === 'true') {
-                editor.on('change', refreshPreview);
-            }else {
+            // Refresh the preview unconditionally on first load.
+            refreshPreview();
+
+            // Set if editor has changed.
+            editor.on('change', function (evt) {
+                var value = editor.getValue();
+                textareaId.val(value);
+                if (editorConfig.living === 'true') {
+                    refreshPreview();
+                }
+            });
+
+            if (editorConfig.living !== 'true') {
               previewTabButton.click(function(){
                   // hide the `.martor-toolbar` for this current editor if under preview.
                   $(this).closest('.tab-martor-menu').find('.martor-toolbar').hide();


### PR DESCRIPTION
This PR makes it so that a rendering of the Markdown content is performed on page load, even when the preview is tabbed. This makes the UX better in case a user clicks the _Preview_ tab immediately; they no longer need to see the "Nothing to preview" message while they wait for their content to appear.