### PR TITLE
Added missing key to MARTOR_ENABLE_CONFIGS.

### DIFF
--- a/martor_demo/martor_demo/settings.py
+++ b/martor_demo/martor_demo/settings.py
@@ -27,10 +27,11 @@ SECRET_KEY = '93fs*#h77*vj&2#2f+!y=kifg0s&63768398a(kx126itq(*6r'
 DEBUG = True
 ALLOWED_HOSTS = ['*']
 MARTOR_ENABLE_CONFIGS = {
-    'imgur': 'true',     # to enable/disable imgur/custom uploader.
-    'mention': 'true',   # to enable/disable mention
-    'jquery': 'true',    # to include/revoke jquery (require for admin default django)
-    'living': 'false'    # to enable/disable live updates in preview
+    'imgur': 'true',         # to enable/disable imgur/custom uploader.
+    'mention': 'true',       # to enable/disable mention
+    'jquery': 'true',        # to include/revoke jquery (require for admin default django)
+    'living': 'false',       # to enable/disable live updates in preview
+    'spellcheck': 'true',    # to enable/disable spellcheck in the editor.
 }
 
 # Application definition


### PR DESCRIPTION
The Problem
The demo application was crashing because the 'spellcheck' key was missing.

The Solution
Add the missing key to the MARTOR_ENABLE_CONFIGS dictionary.