### PR TITLE
Fix demo

### DIFF
--- a/martor/extensions/emoji.py
+++ b/martor/extensions/emoji.py
@@ -2,7 +2,7 @@ import markdown
 from ..settings import (
     MARTOR_MARKDOWN_BASE_EMOJI_URL,
     MARTOR_MARKDOWN_BASE_EMOJI_USE_STATIC)
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags import static
 
 """
 >>> import markdown

--- a/martor_demo/app/templates/base.html
+++ b/martor_demo/app/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}<!DOCTYPE html>
+{% load static %}<!DOCTYPE html>
 <html lang="en-us">
 <head>
   <title>{% block title %}{% endblock %} :: Martor</title>

--- a/martor_demo/app/templates/test_markdownify.html
+++ b/martor_demo/app/templates/test_markdownify.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% load martortags %}
 <!DOCTYPE html>
 <html lang="en-us">

--- a/martor_demo/martor_demo/settings.py
+++ b/martor_demo/martor_demo/settings.py
@@ -27,10 +27,11 @@ SECRET_KEY = '93fs*#h77*vj&2#2f+!y=kifg0s&63768398a(kx126itq(*6r'
 DEBUG = True
 ALLOWED_HOSTS = ['*']
 MARTOR_ENABLE_CONFIGS = {
-    'imgur': 'true',     # to enable/disable imgur/custom uploader.
-    'mention': 'true',   # to enable/disable mention
-    'jquery': 'true',    # to include/revoke jquery (require for admin default django)
-    'living': 'false'    # to enable/disable live updates in preview
+    'imgur': 'true',         # to enable/disable imgur/custom uploader.
+    'mention': 'true',       # to enable/disable mention
+    'jquery': 'true',        # to include/revoke jquery (require for admin default django)
+    'living': 'false',       # to enable/disable live updates in preview
+    'spellcheck': 'true',    # to enable/disable spellcheck in the editor.
 }
 
 # Application definition


### PR DESCRIPTION
Fixes outdated static file tags and properly renders markdown on the current release of Django.

**Please see issue #95 for more details.**

These commits also fix the problems mentioned in issue #49 which are not in fact being caused by Markdown 3.