### PR TITLE
Fix Django 3 incompatibility

### DIFF
--- a/martor/extensions/emoji.py
+++ b/martor/extensions/emoji.py
@@ -2,7 +2,10 @@ import markdown
 from ..settings import (
     MARTOR_MARKDOWN_BASE_EMOJI_URL,
     MARTOR_MARKDOWN_BASE_EMOJI_USE_STATIC)
-from django.conf.urls.static import static
+try:
+    from django.conf.urls.static import static
+except KeyError:
+    from django.contrib.staticfiles.templatetags.staticfiles import static
 
 """
 >>> import markdown

--- a/martor/extensions/emoji.py
+++ b/martor/extensions/emoji.py
@@ -2,7 +2,7 @@ import markdown
 from ..settings import (
     MARTOR_MARKDOWN_BASE_EMOJI_URL,
     MARTOR_MARKDOWN_BASE_EMOJI_USE_STATIC)
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.conf.urls.static import static
 
 """
 >>> import markdown


### PR DESCRIPTION
According to the Django 3 release notes,
`django.contrib.staticfiles.templatetags.staticfiles.static()` is
removed in Django 3.0. Hence, we use `django.conf.urls.static.static()`
instead.

I haven't checked if `static()` from `django.conf.urls.static` was
already available in Django 2 though; so if we want *master* to stay
compatible with Django 2 we should figure out a way to stay
backwards-compatible before merging.

Fixes #101.