### PR TITLE
Updating emoji extension's static import for compatibility with Django 3.0

### DIFF
--- a/martor/extensions/emoji.py
+++ b/martor/extensions/emoji.py
@@ -2,7 +2,10 @@ import markdown
 from ..settings import (
     MARTOR_MARKDOWN_BASE_EMOJI_URL,
     MARTOR_MARKDOWN_BASE_EMOJI_USE_STATIC)
-from django.contrib.staticfiles.templatetags.staticfiles import static
+try:
+    from django.contrib.staticfiles.templatetags.staticfiles import static
+except KeyError:
+    from django.conf.urls.static import static
 
 """
 >>> import markdown


### PR DESCRIPTION
Fix to issue #106 for **KeyError** on _spellcheck_ due to _staticfiles_ no longer being available in Django 3.0.

Working off of @koenw's requested change in #102 and @reOiL's request in #105 as well as @agusmakmun's request for backwards compatibility support. This issue was also reported in #101.

Checking for specific **KeyError** exception, doing a general exception check is too broad.
