### PR TITLE
Use get_user_model and QuerySet filter in mention extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,6 @@ sudo: false
 
 matrix:
   include:
-    - python: 2.7
-      env: DJANGO="==1.8.*"
-    - python: 2.7
-      env: DJANGO="==1.9.*"
-    - python: 2.7
-      env: DJANGO="==1.10.*"
-    - python: 2.7
-      env: DJANGO="==1.11.*"
-
     - python: 3.4
       env: DJANGO="==1.8.*"
     - python: 3.4

--- a/martor/extensions/mention.py
+++ b/martor/extensions/mention.py
@@ -23,11 +23,11 @@ class MentionPattern(markdown.inlinepatterns.Pattern):
 
     def handleMatch(self, m):
         username = self.unescape(m.group(2))
-        user_check = get_user_model().objects.filter(username=username, is_active=True)
+        users = get_user_model().objects.filter(username=username, is_active=True)
 
         """Makesure `username` is registered and actived."""
         if MARTOR_ENABLE_CONFIGS['mention'] == 'true':
-            if user_check.exists():
+            if users.exists():
                 url = '{0}{1}/'.format(MARTOR_MARKDOWN_BASE_MENTION_URL, username)
                 el = markdown.util.etree.Element('a')
                 el.set('href', url)

--- a/martor/extensions/mention.py
+++ b/martor/extensions/mention.py
@@ -1,5 +1,5 @@
 import markdown
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from ..settings import (
     MARTOR_ENABLE_CONFIGS,
     MARTOR_MARKDOWN_BASE_MENTION_URL
@@ -23,10 +23,11 @@ class MentionPattern(markdown.inlinepatterns.Pattern):
 
     def handleMatch(self, m):
         username = self.unescape(m.group(2))
+        user_check = get_user_model().objects.filter(username=username, is_active=True)
 
         """Makesure `username` is registered and actived."""
         if MARTOR_ENABLE_CONFIGS['mention'] == 'true':
-            if username in [u.username for u in User.objects.exclude(is_active=False)]:
+            if user_check.exists():
                 url = '{0}{1}/'.format(MARTOR_MARKDOWN_BASE_MENTION_URL, username)
                 el = markdown.util.etree.Element('a')
                 el.set('href', url)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: JavaScript',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Following the [Django Docs](https://docs.djangoproject.com/en/3.0/topics/auth/customizing/#referencing-the-user-model), using `get_user_model()` instead of a direct reference to `User` should make the mentions extension more flexible, for projects with models based on `AbstractUser`. Additionally, using the `exists()` method with a `QuerySet` filter provides a more optimized way to check the username match. 