### PR TITLE
Fix issue #169 (force_text depracated)

### DIFF
--- a/martor/utils.py
+++ b/martor/utils.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.utils.functional import Promise
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.core.serializers.json import DjangoJSONEncoder
 
 import markdown
@@ -56,5 +56,5 @@ class LazyEncoder(DjangoJSONEncoder):
 
     def default(self, obj):
         if isinstance(obj, Promise):
-            return force_text(obj)
+            return force_str(obj)
         return super(LazyEncoder, self).default(obj)

--- a/martor/utils.py
+++ b/martor/utils.py
@@ -2,8 +2,12 @@
 from __future__ import unicode_literals
 
 from django.utils.functional import Promise
-from django.utils.encoding import force_str
 from django.core.serializers.json import DjangoJSONEncoder
+
+try:
+    from django.utils.encoding import force_str  # noqa: Django>=4.x
+except ImportError:
+    from django.utils.encoding import force_text as force_str  # noqa: Django<=3.x
 
 import markdown
 from .settings import (


### PR DESCRIPTION
Alias 'force_text' was deprecated in django 3.0 and is gone with 4.0
(https://docs.djangoproject.com/en/4.0/releases/3.0/#features-deprecated-in-3-0)