### PR TITLE
Fix deprecated use of ugettext_lazy

### DIFF
--- a/martor/views.py
+++ b/martor/views.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.http import (HttpResponse, JsonResponse)
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import get_user_model
 


### PR DESCRIPTION
Change to gettext_lazy. ugettext_lazy was removed in Django 4.0, and has been an alias to gettext_lazy since Django 2.0.