### PR TITLE
Authenticated markdownfy_view

### DIFF
--- a/martor/views.py
+++ b/martor/views.py
@@ -14,6 +14,7 @@ from .utils import LazyEncoder
 User = get_user_model()
 
 
+@login_required
 def markdownfy_view(request):
     if request.method == "POST":
         content = request.POST.get("content", "")


### PR DESCRIPTION
Added `login_required` to `markdownfy_view` method, so it is not unauthenticated.

Fixes: https://github.com/agusmakmun/django-markdown-editor/issues/194

