### PR TITLE
#issue-205 Add `tzdata` to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django>=3.2
 Markdown==3.3.4
 requests
 bleach
+tzdata


### PR DESCRIPTION
Fix issue #205 : Resolved ModuleNotFoundError when accessing the /admin page hosted within the container built from martor_demo's Dockerfile for Django version 4.2, by including `tzdata` package in the requirements.txt.