### PR TITLE
The 'row' argument was removed in recent versions of Django

### DIFF
--- a/martor/static/martor/js/martor.bootstrap.js
+++ b/martor/static/martor/js/martor.bootstrap.js
@@ -860,9 +860,10 @@
     });
 
     if ('django' in window && 'jQuery' in window.django)
-        django.jQuery(document).on('formset:added', function (event, $row) {
-            $row.find('.main-martor').each(function () {
-                var id = $row.attr('id');
+        django.jQuery(document).on('formset:added', function (event) {
+            var row = $(event.target);
+            row.find('.main-martor').each(function () {
+                var id = row.attr('id');
                 id = id.substr(id.lastIndexOf('-') + 1);
                 // Notice here we are using our jQuery instead of Django's.
                 // This is because plugins are only loaded for ours.


### PR DESCRIPTION
But we can still find it in the event.target object, this commit solves the problem (only in the not minified js version).

Thanks! Good work! we are using this app in https://github.com/ladiaria/utopia-cms/ (the backend we use for our newspaper website ladiaria.com.uy)