### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 urllib3<2 ; python_version < '3.7' # urllib3 2.0 dropped support for Python 3.6
 zipp<3.7 ; python_version < '3.7' # zipp 3.7.0 dropped support for Python 3.6
 importlib_metadata<4.9 # # importlib_metadata 4.9.0 dropped support for Python 3.6
-Django>=3.2
+Django>=3.2, <=4.2
 Markdown<3.4
 requests
 bleach


### PR DESCRIPTION
The supported Django version limitation for the correct operation of the README.md instructions. I encountered an issue where the default installation is Django 5 beta, and further instructions for running the demo result in an error.