### PR TITLE
Adjust regex so that it does not strip links inadvertently

### DIFF
--- a/martor/utils.py
+++ b/martor/utils.py
@@ -33,10 +33,14 @@ def markdownify(markdown_text):
     # Sanitize Markdown links
     # https://github.com/netbox-community/netbox/commit/5af2b3c2f577a01d177cb24cda1019551a2a4b64
     schemes = "|".join(ALLOWED_URL_SCHEMES)
-    pattern = fr"\[(.+)\]\((?!({schemes})).*(:|;)(.+)\)"
+
+    # Adjusted pattern to focus on links that do not follow the allowed schemes directly
+    # The negative lookahead now correctly positioned to ensure it applies to the whole URL
+    pattern = rf"\[([^\]]+)\]\(((?!({schemes}):)[^)]+)\)"
+
     markdown_text = re.sub(
         pattern,
-        "[\\1](\\3)",
+        "[\\1](\\2)",
         markdown_text,
         flags=re.IGNORECASE,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 urllib3<2 ; python_version < '3.7' # urllib3 2.0 dropped support for Python 3.6
 zipp<3.7 ; python_version < '3.7' # zipp 3.7.0 dropped support for Python 3.6
 importlib_metadata<4.9 # # importlib_metadata 4.9.0 dropped support for Python 3.6
-Django>=3.2, <=4.2
+Django>=3.2, <=4.2.10
 Markdown<3.4
 requests
 bleach

--- a/setup.py
+++ b/setup.py
@@ -1,44 +1,46 @@
-from setuptools import (setup, find_packages)
-from martor import (__VERSION__, __AUTHOR__, __AUTHOR_EMAIL__)
+from setuptools import setup, find_packages
+from martor import __VERSION__, __AUTHOR__, __AUTHOR_EMAIL__
 
 
 def get_requirements():
-    return open('requirements.txt').read().splitlines()
+    return open("requirements.txt").read().splitlines()
 
 
 setup(
-    name='martor',
+    name="martor",
     version=__VERSION__,
     packages=find_packages(exclude=["*demo"]),
     include_package_data=True,
     zip_safe=False,
-    description='Django Markdown Editor',
-    url='https://github.com/agusmakmun/django-markdown-editor',
-    download_url='https://github.com/agusmakmun/django-markdown-editor/tarball/v%s' % __VERSION__,
-    keywords=['martor', 'django markdown', 'django markdown editor'],
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
-    license='GNUGPL-v3',
+    description="Django Markdown Editor",
+    url="https://github.com/agusmakmun/django-markdown-editor",
+    download_url="https://github.com/agusmakmun/django-markdown-editor/tarball/v%s"
+    % __VERSION__,
+    keywords=["martor", "django markdown", "django markdown editor"],
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    license="GNUGPL-v3",
     author=__AUTHOR__,
     author_email=__AUTHOR_EMAIL__,
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Web Environment',
-        'Framework :: Django',
-        'Framework :: Django :: 3.2',
-        'Framework :: Django :: 4.0',
-        'Framework :: Django :: 4.1',
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-        'Programming Language :: JavaScript',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Web Environment",
+        "Framework :: Django",
+        "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.0",
+        "Framework :: Django :: 4.1",
+        "Framework :: Django :: 4.2",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: JavaScript",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     ],
     install_requires=get_requirements(),
 )


### PR DESCRIPTION
The issue with the current implementation seems to stem from the regex pattern mistakenly capturing and modifying links that should be left untouched, especially when they contain colons (:) or semicolons (;) that are part of a normal URL or anchor reference (#).

This was leading to issues where text would be lost where a paragraph would contain more than one link and a semi-colon.

eg:

- for this input:
  - `Citation 4. [footnote 4](#ftnt4) Citation 5. [footnote 5](#ftnt5) Citation 6; [footnote 6](#ftnt6)`
- we were getting this output:
  - `<p>Citation 4. <a href="#ftnt4">footnote 4</a> Citation 5. <a href=";">footnote 5</a></p>`
- when what we wanted was this:
  - `<p>Citation 4. <a href="#ftnt4">footnote 4</a> Citation 5. <a href="#ftnt5">footnote 5</a> Citation 6; <a href="#ftnt6">footnote 6</a></p>`

This PR fixes this so that regular links are preserved, but keeps in place the logic stripping bad protocols.

Closes this issue:
- https://github.com/agusmakmun/django-markdown-editor/issues/229