### PR TITLE
Mention configuration

### DIFF
--- a/martor/tests/tests.py
+++ b/martor/tests/tests.py
@@ -7,7 +7,6 @@ from django.test import TestCase, override_settings
 from django.urls import clear_url_caches, resolve, reverse
 
 from martor.utils import markdownify
-from martor.views import markdown_imgur_uploader, markdown_search_user, markdownfy_view
 
 
 class SimpleTest(TestCase):
@@ -15,6 +14,8 @@ class SimpleTest(TestCase):
         # Reload settings.py and urls.py when @override_settings is called
         clear_url_caches()
         reload(sys.modules["martor.settings"])
+        if "martor.views" in sys.modules:
+            reload(sys.modules["martor.views"])
         reload(sys.modules["martor.urls"])
         reload(sys.modules["martor.tests.urls"])
 
@@ -135,6 +136,28 @@ class SimpleTest(TestCase):
             '<p><a href="&quot; onmouseover=alert(document.domain)">xss</a>)</p>',  # noqa: E501
         )
 
+    @override_settings(
+        MARTOR_ENABLE_CONFIGS={
+            "mention": "false",
+        }
+    )
+    def test_search_user_mention_disabled(self):
+        response = self.client.get(reverse("search_user_json") + "?username=user")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], 403)
+        self.assertEqual(response.json()["error"], "This feature is disabled, check the documentation")
+
+    @override_settings(
+        MARTOR_ENABLE_CONFIGS={
+            "mention": "true",
+        }
+    )
+    def test_search_user_mention_enabled(self):
+        response = self.client.get(reverse("search_user_json") + "?username=user1")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], 200)
+        self.assertEqual(response.json()["data"], ["user1"])
+
     def test_urls(self):
         with override_settings(
             MARTOR_MARKDOWNIFY_URL="test/url",
@@ -142,13 +165,13 @@ class SimpleTest(TestCase):
             MARTOR_SEARCH_USERS_URL="test/search",
         ):
             found = resolve(reverse("martor_markdownfy"))
-            self.assertEqual(found.func, markdownfy_view)
+            self.assertEqual(found.func.__name__, "markdownfy_view")
 
             found = resolve(reverse("imgur_uploader"))
-            self.assertEqual(found.func, markdown_imgur_uploader)
+            self.assertEqual(found.func.__name__, "markdown_imgur_uploader")
 
             found = resolve(reverse("search_user_json"))
-            self.assertEqual(found.func, markdown_search_user)
+            self.assertEqual(found.func.__name__, "markdown_search_user")
 
 
 class MarkdownifyTest(TestCase):

--- a/martor/views.py
+++ b/martor/views.py
@@ -5,7 +5,7 @@ from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 
 from .api import imgur_uploader
-from .settings import MARTOR_MARKDOWNIFY_FUNCTION
+from .settings import MARTOR_MARKDOWNIFY_FUNCTION, MARTOR_ENABLE_CONFIGS
 from .utils import LazyEncoder
 
 User = get_user_model()

--- a/martor/views.py
+++ b/martor/views.py
@@ -59,22 +59,29 @@ def markdown_search_user(request):
                     {'usernane': 'albert'}]
                 }
     """
+
+
+
     response_data = {}
-    username = request.GET.get("username")
 
-    if username is not None and username != "" and " " not in username:
-        queries = {"%s__icontains" % User.USERNAME_FIELD: username}
-        users = User.objects.filter(**queries).filter(is_active=True)
-        if users.exists():
-            usernames = list(users.values_list("username", flat=True))
-            response_data.update({"status": 200, "data": usernames})
-            return JsonResponse(response_data)
-
-        error_message = _("No users registered as `%(username)s` " "or user is unactived.")
-        error_message = error_message % {"username": username}
-        response_data.update({"status": 204, "error": error_message})
+    if MARTOR_ENABLE_CONFIGS.get("mention") == "false":
+        response_data.udpate({"status":"403", "error": _("This featured is disabled, check the documentation")})
     else:
-        error_message = _("Validation Failed for field `username`")
-        response_data.update({"status": 204, "error": error_message})
+        username = request.GET.get("username")
+
+        if username is not None and username != "" and " " not in username:
+            queries = {"%s__icontains" % User.USERNAME_FIELD: username}
+            users = User.objects.filter(**queries).filter(is_active=True)
+            if users.exists():
+                usernames = list(users.values_list("username", flat=True))
+                response_data.update({"status": 200, "data": usernames})
+                return JsonResponse(response_data)
+
+            error_message = _("No users registered as `%(username)s` " "or user is unactived.")
+            error_message = error_message % {"username": username}
+            response_data.update({"status": 204, "error": error_message})
+        else:
+            error_message = _("Validation Failed for field `username`")
+            response_data.update({"status": 204, "error": error_message})
 
     return JsonResponse(response_data, encoder=LazyEncoder)

--- a/martor/views.py
+++ b/martor/views.py
@@ -5,7 +5,7 @@ from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 
 from .api import imgur_uploader
-from .settings import MARTOR_MARKDOWNIFY_FUNCTION, MARTOR_ENABLE_CONFIGS
+from .settings import MARTOR_ENABLE_CONFIGS, MARTOR_MARKDOWNIFY_FUNCTION
 from .utils import LazyEncoder
 
 User = get_user_model()
@@ -60,12 +60,10 @@ def markdown_search_user(request):
                 }
     """
 
-
-
     response_data = {}
 
     if MARTOR_ENABLE_CONFIGS.get("mention") == "false":
-        response_data.udpate({"status":"403", "error": _("This featured is disabled, check the documentation")})
+        response_data.update({"status": 403, "error": _("This feature is disabled, check the documentation")})
     else:
         username = request.GET.get("username")
 


### PR DESCRIPTION
Check the settings; only use this endpoint if the mentions feature is enabled.

This can make it easier to identify users, which could pose a security risk; however, it gives the developer the option to disable this feature.